### PR TITLE
Transpile levenshtein

### DIFF
--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -182,14 +182,6 @@ def _unnest_to_explode_sql(self, expression):
     return self.join_sql(expression)
 
 
-def _levenshtein_sql(self, expression, levenshtein_function):
-
-    expr = expression.args.get("expression")
-    this = self.sql(expression, "this")
-    expr = ", ".join([self.sql(e) for e in expr])
-    return f"{levenshtein_function}({this}, {expr})"
-
-
 def _struct_extract_sql(self, expression):
     this = self.sql(expression, "this")
     struct_key = self.sql(expression, "expression").replace(self.quote, self.identifier)
@@ -670,7 +662,7 @@ class Presto(Dialect):
         exp.ILike: _no_ilike_sql,
         exp.Initcap: _initcap_sql,
         exp.Lateral: _explode_to_unnest_sql,
-        exp.Levenshtein: lambda self, e: _levenshtein_sql(self, e, levenshtein_function="LEVENSHTEIN_DISTANCE"),
+        exp.Levenshtein: lambda self, e: f"LEVENSHTEIN_DISTANCE({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
         exp.Quantile: _quantile_sql,
         exp.Schema: _schema_sql,
         exp.StrPosition: _str_position_sql,
@@ -790,7 +782,7 @@ class SQLite(Dialect):
     }
 
     transforms = {
-        exp.Levenshtein: lambda self, e: _levenshtein_sql(self, e, levenshtein_function="EDITDIST3"),
+        exp.Levenshtein: lambda self, e: f"EDITDIST3({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
         exp.TableSample: _no_tablesample_sql,
         exp.TryCast: _no_trycast_sql,
     }

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -185,9 +185,6 @@ def _unnest_to_explode_sql(self, expression):
 def _levenshtein_sql(self, expression, levenshtein_function):
 
     expr = expression.args.get("expression")
-    if not expr:
-        raise ValueError("Error: No comparison provided for levenshtein function.")
-
     this = self.sql(expression, "this")
     expr = ", ".join([self.sql(e) for e in expr])
     return f"{levenshtein_function}({this}, {expr})"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1699,7 +1699,6 @@ class Length(Func):
 
 class Levenshtein(Func):
     arg_types = {"this": True, "expression": False}
-    is_var_len_args = True
 
 
 class Ln(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1697,6 +1697,11 @@ class Length(Func):
     pass
 
 
+class Levenshtein(Func):
+    arg_types = {"this": True, "expression": False}
+    is_var_len_args = True
+
+
 class Ln(Func):
     pass
 

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -803,13 +803,13 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "LEVENSHTEIN(col1, col2)",
             "LEVENSHTEIN_DISTANCE(col1, col2)",
-            write="presto"
+            write="presto",
         )
 
         self.validate(
             "LEVENSHTEIN(coalesce(col1, col2), coalesce(col2, col1))",
-            "LEVENSHTEIN_DISTANCE(coalesce(col1, col2), coalesce(col2, col1))",
-            write="presto"
+            "LEVENSHTEIN_DISTANCE(COALESCE(col1, col2), COALESCE(col2, col1))",
+            write="presto",
         )
 
     def test_hive(self):
@@ -1312,9 +1312,7 @@ class TestDialects(unittest.TestCase):
         )
 
         self.validate(
-            "LEVENSHTEIN(col1, col2)",
-            "EDITDIST3(col1, col2)",
-            write="sqlite"
+            "LEVENSHTEIN(col1, col2)", "EDITDIST3(col1, col2)", write="sqlite"
         )
 
     def test_oracle(self):

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -800,6 +800,18 @@ class TestDialects(unittest.TestCase):
             write="spark",
         )
 
+        self.validate(
+            "LEVENSHTEIN(col1, col2)",
+            "LEVENSHTEIN_DISTANCE(col1, col2)",
+            write="presto"
+        )
+
+        self.validate(
+            "LEVENSHTEIN(coalesce(col1, col2), coalesce(col2, col1))",
+            "LEVENSHTEIN_DISTANCE(coalesce(col1, col2), coalesce(col2, col1))",
+            write="presto"
+        )
+
     def test_hive(self):
         sql = transpile('SELECT "a"."b" FROM "foo"', write="hive")[0]
         self.assertEqual(sql, "SELECT `a`.`b` FROM `foo`")
@@ -1297,6 +1309,11 @@ class TestDialects(unittest.TestCase):
             'CAST("a"."b" AS INTEGER)',
             read="spark",
             write="sqlite",
+        )
+
+        self.validate(
+            "LEVENSHTEIN(col1, col2)",
+            "EDITDIST3(col1, col2)"
         )
 
     def test_oracle(self):

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1313,7 +1313,8 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "LEVENSHTEIN(col1, col2)",
-            "EDITDIST3(col1, col2)"
+            "EDITDIST3(col1, col2)",
+            write="sqlite"
         )
 
     def test_oracle(self):


### PR DESCRIPTION
The  `_levenshtein_sql`  simply grabs the arguments from inside a `levenshtein()` call and then transpiles `levenshtein` to either `levenshtein_distance` or `editdist3`, depending on the dialect chosen.

The code currently also errors if you only supply a single argument - i.e. `levenshtein(col1)`.